### PR TITLE
Use pluggable User model

### DIFF
--- a/userflags/models.py
+++ b/userflags/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 
-from django.contrib.auth.models import User
+from django.conf import settings
+from django.contrib.auth import get_user_model
 
 
 class FlagMananager(models.Manager):
@@ -9,7 +10,7 @@ class FlagMananager(models.Manager):
 
 
 class Flag(models.Model):
-    users = models.ManyToManyField(User, blank=True)
+    users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True)
     name = models.CharField(max_length=255)
 
     objects = FlagMananager()
@@ -37,6 +38,7 @@ class Flag(models.Model):
             self.save()
 
     def has_user(self, user):
+        User = get_user_model()
         try:
             self.users.get(id=user.id)
         except User.DoesNotExist:

--- a/userflags/templatetags/userflags_extras.py
+++ b/userflags/templatetags/userflags_extras.py
@@ -1,7 +1,7 @@
 import re
 
 from django import template
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 
@@ -17,6 +17,7 @@ class FlagsNode(template.Node):
         self.var_name = var_name
 
     def render(self, context):
+        User = get_user_model()
         user_id = self.user_id.resolve(context)
         user = User.objects.get(pk=user_id)
 

--- a/userflags/views.py
+++ b/userflags/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404
 
@@ -12,6 +12,7 @@ def _redirect_when_possible(request):
 
 
 def link(request, user_id, flag_id):
+    User = get_user_model()
     user = get_object_or_404(User, pk=user_id)
     flag = get_object_or_404(Flag, pk=flag_id)
     flag.add_user(user)
@@ -19,6 +20,7 @@ def link(request, user_id, flag_id):
 
 
 def unlink(request, user_id, flag_id):
+    User = get_user_model()
     user = get_object_or_404(User, pk=user_id)
     flag = get_object_or_404(Flag, pk=flag_id)
     flag.remove_user(user)


### PR DESCRIPTION
Instead of hardcoding the usage of auth.User allow for a pluggable/custom user model.